### PR TITLE
Fix timezone handling for Open-Meteo API responses

### DIFF
--- a/custom_components/soil_temperature/coordinator.py
+++ b/custom_components/soil_temperature/coordinator.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from datetime import timedelta
+from datetime import datetime, timedelta, timezone
 import logging
 from statistics import mean
 from typing import TypeAlias
@@ -120,6 +120,11 @@ class SoilTemperatureCoordinator(DataUpdateCoordinator[SoilTemperatureData]):
         if not time_list:
             raise UpdateFailed("No hourly data returned from Open-Meteo")
 
+        # Build the timezone from the API response so naive timestamps
+        # become offset-aware and can be compared with dt_util.now().
+        utc_offset = data.get("utc_offset_seconds", 0)
+        api_tz = timezone(timedelta(seconds=utc_offset))
+
         now = dt_util.now()
         result = SoilTemperatureData()
 
@@ -138,6 +143,8 @@ class SoilTemperatureCoordinator(DataUpdateCoordinator[SoilTemperatureData]):
                     ts = dt_util.parse_datetime(t)
                     if ts is None:
                         continue
+                    if ts.tzinfo is None:
+                        ts = ts.replace(tzinfo=api_tz)
                     paired.append((ts, values[i]))
 
             if not paired:


### PR DESCRIPTION
## Summary
This PR fixes timezone handling when processing Open-Meteo API responses to ensure naive timestamps are converted to timezone-aware datetimes before comparison with the current time.

## Key Changes
- Import `datetime` and `timezone` from the datetime module to support timezone operations
- Extract the `utc_offset_seconds` from the API response and construct a timezone object from it
- Apply the API timezone to any naive timestamps before adding them to the paired data list, ensuring they can be properly compared with `dt_util.now()`

## Implementation Details
The fix addresses a potential issue where timestamps returned by the Open-Meteo API without timezone information (naive datetimes) could not be reliably compared with timezone-aware datetime objects. By extracting the UTC offset from the API response and applying it to naive timestamps, all timestamps are now offset-aware and can be safely compared with the current time obtained from `dt_util.now()`.

https://claude.ai/code/session_01LRjMgNdDfp7gA8jgnyGk42