### PR TITLE
Convert soil temperature forecasts to user's configured unit

### DIFF
--- a/custom_components/soil_temperature/sensor.py
+++ b/custom_components/soil_temperature/sensor.py
@@ -12,6 +12,7 @@ from homeassistant.components.sensor import (
     SensorStateClass,
 )
 from homeassistant.const import UnitOfTemperature
+from homeassistant.util.unit_conversion import TemperatureConverter
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceEntryType, DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -157,7 +158,15 @@ class SoilTemperatureSensor(
         depth_data = self.coordinator.data.depths.get(depth)
         if depth_data is None or not depth_data.forecast_daily:
             return None
+        target_unit = self.hass.config.units.temperature_unit
         attrs: dict[str, str | float] = {}
         for date_str, temp in depth_data.forecast_daily.items():
-            attrs[f"forecast_{date_str}"] = temp
+            if target_unit != UnitOfTemperature.CELSIUS:
+                converted = TemperatureConverter.convert(
+                    temp, UnitOfTemperature.CELSIUS, target_unit
+                )
+                attrs[f"forecast_{date_str}"] = round(converted, 1)
+            else:
+                attrs[f"forecast_{date_str}"] = temp
+        attrs["forecast_unit"] = target_unit
         return attrs


### PR DESCRIPTION
## Summary
This PR adds automatic temperature unit conversion for soil temperature forecast attributes, ensuring they respect the user's Home Assistant configuration instead of always displaying in Celsius.

## Key Changes
- Import `TemperatureConverter` from Home Assistant utilities
- Retrieve the user's configured temperature unit from `hass.config.units.temperature_unit`
- Convert forecast temperatures from Celsius to the target unit when they differ
- Round converted temperatures to 1 decimal place for consistency
- Add a new `forecast_unit` attribute to indicate which unit the forecasts are displayed in

## Implementation Details
- Conversion only occurs when the target unit is not Celsius, avoiding unnecessary processing
- The forecast data is stored internally in Celsius and converted on-the-fly for display
- The new `forecast_unit` attribute provides transparency about the unit being used for the forecast values

https://claude.ai/code/session_01Fo6dgX3zoNPvSgcJz7n24i