### PR TITLE
Remove forecast_unit attribute from soil temperature sensor

### DIFF
--- a/custom_components/soil_temperature/sensor.py
+++ b/custom_components/soil_temperature/sensor.py
@@ -168,5 +168,4 @@ class SoilTemperatureSensor(
                 attrs[f"forecast_{date_str}"] = round(converted, 1)
             else:
                 attrs[f"forecast_{date_str}"] = temp
-        attrs["forecast_unit"] = target_unit
         return attrs


### PR DESCRIPTION
## Summary
Removed the `forecast_unit` attribute from the extra state attributes of the soil temperature sensor.

## Changes
- Removed the line that adds `forecast_unit` to the sensor's extra state attributes dictionary

## Details
The `forecast_unit` attribute was being added to track the unit of the forecast values, but this information is no longer needed in the sensor's state attributes. The forecast temperature values themselves remain in the attributes with their respective conversions applied.

https://claude.ai/code/session_018wqo8S23d4JBL7MJH8CVBk