### PR TITLE
Add static forecast attribute naming mode for dashboard compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A custom Home Assistant integration that provides soil temperature data at multi
 - Soil temperature at up to 4 depths: 0cm (surface), 6cm, 18cm, and 54cm
 - Configurable depth selection — choose which depths to monitor during setup or later via options
 - Current temperature, 24-hour average, and 5-day average for each selected depth
-- 7-day daily forecast included as attributes in 24-hour average sensors
+- 7-day daily forecast included as attributes in 24-hour average sensors, with an optional static naming mode for dashboard card compatibility
 - Zone-based configuration (uses your HA zone's coordinates)
 - 30-minute polling interval
 - HACS compatible
@@ -47,7 +47,19 @@ For each selected soil depth, three sensors are created:
 
 The 6cm depth sensors use simplified names (e.g., "Soil Temperature Current") since this is the most commonly referenced depth for gardening and agriculture.
 
-24-hour average temperature sensors include a 7-day daily forecast as extra state attributes (e.g., `forecast_2024-03-15: 52.3`).
+24-hour average temperature sensors include a 7-day daily forecast as extra state attributes. By default, attributes are named by date (e.g., `forecast_2024-03-15: 52.3`).
+
+### Static Forecast Attribute Names
+
+Enable **"Use static forecast attribute names"** in the integration options to switch to indexed attribute names that don't change daily. This is useful for dashboard cards like [Bubble Card](https://github.com/Clooos/Bubble-Card) sub-buttons that require static attribute references.
+
+| Attribute | Description |
+|-----------|-------------|
+| `forecast_0d` | Today's forecast temperature |
+| `forecast_0d_date` | Today's date (e.g., `2024-03-15`) |
+| `forecast_1d` | Tomorrow's forecast temperature |
+| `forecast_1d_date` | Tomorrow's date |
+| ... | Up to `forecast_6d` / `forecast_6d_date` |
 
 All temperatures are reported in Celsius. Home Assistant will automatically convert to Fahrenheit if your system is configured for imperial units.
 

--- a/custom_components/soil_temperature/config_flow.py
+++ b/custom_components/soil_temperature/config_flow.py
@@ -17,7 +17,14 @@ from homeassistant.core import callback
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.selector import EntitySelector, EntitySelectorConfig
 
-from .const import CONF_DEPTHS, CONF_ZONE, DEFAULT_DEPTHS, DOMAIN, SOIL_DEPTHS
+from .const import (
+    CONF_DEPTHS,
+    CONF_STATIC_FORECAST_ATTRS,
+    CONF_ZONE,
+    DEFAULT_DEPTHS,
+    DOMAIN,
+    SOIL_DEPTHS,
+)
 
 DEPTH_OPTIONS = {str(d): f"{d} cm" for d in SOIL_DEPTHS}
 
@@ -104,7 +111,12 @@ class SoilTemperatureOptionsFlowHandler(OptionsFlow):
                     errors={"base": "no_depths"},
                 )
             return self.async_create_entry(
-                data={CONF_DEPTHS: selected_depths},
+                data={
+                    CONF_DEPTHS: selected_depths,
+                    CONF_STATIC_FORECAST_ATTRS: user_input.get(
+                        CONF_STATIC_FORECAST_ATTRS, False
+                    ),
+                },
             )
 
         return self.async_show_form(
@@ -117,11 +129,18 @@ class SoilTemperatureOptionsFlowHandler(OptionsFlow):
         current_depths = self.config_entry.options.get(
             CONF_DEPTHS, DEFAULT_DEPTHS
         )
+        current_static = self.config_entry.options.get(
+            CONF_STATIC_FORECAST_ATTRS, False
+        )
         return vol.Schema(
             {
                 vol.Optional(
                     CONF_DEPTHS,
                     default=[str(d) for d in current_depths],
                 ): cv.multi_select(DEPTH_OPTIONS),
+                vol.Optional(
+                    CONF_STATIC_FORECAST_ATTRS,
+                    default=current_static,
+                ): bool,
             }
         )

--- a/custom_components/soil_temperature/const.py
+++ b/custom_components/soil_temperature/const.py
@@ -10,6 +10,7 @@ OPEN_METEO_FORECAST_URL = "https://api.open-meteo.com/v1/forecast"
 
 CONF_ZONE = "zone"
 CONF_DEPTHS = "depths"
+CONF_STATIC_FORECAST_ATTRS = "static_forecast_attrs"
 
 SOIL_DEPTHS = [0, 6, 18, 54]
 DEFAULT_DEPTHS = [6]

--- a/custom_components/soil_temperature/sensor.py
+++ b/custom_components/soil_temperature/sensor.py
@@ -20,7 +20,7 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from homeassistant.helpers import entity_registry as er
 
-from .const import CONF_DEPTHS, DEFAULT_DEPTHS, DOMAIN
+from .const import CONF_DEPTHS, CONF_STATIC_FORECAST_ATTRS, DEFAULT_DEPTHS, DOMAIN
 from .coordinator import (
     SoilTemperatureConfigEntry,
     SoilTemperatureCoordinator,
@@ -159,13 +159,22 @@ class SoilTemperatureSensor(
         if depth_data is None or not depth_data.forecast_daily:
             return None
         target_unit = self.hass.config.units.temperature_unit
+        use_static = self.coordinator.config_entry.options.get(
+            CONF_STATIC_FORECAST_ATTRS, False
+        )
         attrs: dict[str, str | float] = {}
-        for date_str, temp in depth_data.forecast_daily.items():
+        for i, date_str in enumerate(sorted(depth_data.forecast_daily)):
+            temp = depth_data.forecast_daily[date_str]
             if target_unit != UnitOfTemperature.CELSIUS:
-                converted = TemperatureConverter.convert(
-                    temp, UnitOfTemperature.CELSIUS, target_unit
+                temp = round(
+                    TemperatureConverter.convert(
+                        temp, UnitOfTemperature.CELSIUS, target_unit
+                    ),
+                    1,
                 )
-                attrs[f"forecast_{date_str}"] = round(converted, 1)
+            if use_static:
+                attrs[f"forecast_{i}d"] = temp
+                attrs[f"forecast_{i}d_date"] = date_str
             else:
                 attrs[f"forecast_{date_str}"] = temp
         return attrs

--- a/custom_components/soil_temperature/strings.json
+++ b/custom_components/soil_temperature/strings.json
@@ -24,7 +24,8 @@
         "title": "Soil Temperature Options",
         "description": "Select the soil depths to monitor.",
         "data": {
-          "depths": "Soil depths"
+          "depths": "Soil depths",
+          "static_forecast_attrs": "Use static forecast attribute names (for Bubble Card)"
         }
       }
     },


### PR DESCRIPTION
## Summary
This PR adds an optional configuration option to use static, indexed attribute names for forecast data instead of date-based names. This enables compatibility with dashboard cards like Bubble Card that require consistent attribute references.

## Key Changes
- **New configuration option**: Added `CONF_STATIC_FORECAST_ATTRS` to allow users to toggle between dynamic (date-based) and static (indexed) forecast attribute naming
- **Config flow updates**: 
  - Added the new boolean option to the configuration schema in `config_flow.py`
  - Option is persisted in the config entry data
- **Sensor attribute generation**: Modified `extra_state_attributes()` in `sensor.py` to:
  - Check the new configuration option
  - When enabled, use indexed naming (`forecast_0d`, `forecast_1d`, etc.) with corresponding date attributes (`forecast_0d_date`, `forecast_1d_date`, etc.)
  - When disabled, maintain the original date-based naming (`forecast_2024-03-15`, etc.)
- **Documentation**: Updated README with explanation of the static naming mode and attribute reference table
- **Localization**: Added user-friendly label for the new option in `strings.json`

## Implementation Details
- The forecast attributes are now sorted by date to ensure consistent ordering regardless of API response order
- Temperature conversion and rounding logic was refactored for clarity
- The feature is opt-in with a default value of `False` to maintain backward compatibility

https://claude.ai/code/session_01CWjt1ixvgra5BbNdE8JJrs